### PR TITLE
Added dynamic Turret & Cannon classes

### DIFF
--- a/oct_turrets/base.py
+++ b/oct_turrets/base.py
@@ -5,6 +5,21 @@ import zmq
 import uuid
 from threading import Thread
 
+from oct_turrets import utils
+
+DEFAULT_TURRET_CLASS = 'oct_turrets.turret.Turret'
+DEFAULT_CANNON_CLASS = 'oct_turrets.cannon.Cannon'
+
+
+def get_turret_class(path=None):
+    path = path or DEFAULT_TURRET_CLASS
+    return utils.import_object(path)
+
+
+def get_cannon_class(path=None):
+    path = path or DEFAULT_CANNON_CLASS
+    return utils.import_object(path)
+
 
 class BaseTurret(object):
     """The base turret class

--- a/oct_turrets/start_turret.py
+++ b/oct_turrets/start_turret.py
@@ -6,7 +6,7 @@ import logging
 import tarfile
 import tempfile
 import argparse
-from oct_turrets.turret import Turret
+from oct_turrets.base import get_turret_class
 from oct_turrets.exceptions import InvalidConfiguration, InvalidTarTurret
 from oct_turrets.utils import validate_conf, clean_tar_tmp, load_file
 
@@ -76,6 +76,7 @@ def start(args):
     else:
         module, config = from_config(args.config)
 
+    Turret = get_turret_class(config.get('turret_class'))
     turret = Turret(config, module, unique_id)
 
     try:

--- a/oct_turrets/turret.py
+++ b/oct_turrets/turret.py
@@ -4,8 +4,7 @@ import json
 import logging
 import traceback
 
-from oct_turrets.base import BaseTurret
-from oct_turrets.cannon import Cannon
+from oct_turrets.base import BaseTurret, get_cannon_class
 
 log = logging.getLogger(__name__)
 
@@ -79,6 +78,7 @@ class Turret(BaseTurret):
         else:
             timeout = 1000
 
+        Cannon = get_cannon_class(self.config.get('cannon_class'))
         try:
             while self.run_loop:
                 if len(self.cannons) < self.config['cannons'] and time.time() - last_insert >= rampup:

--- a/oct_turrets/utils.py
+++ b/oct_turrets/utils.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import shutil
 import tempfile
+import importlib
 
 from oct_turrets.config import REQUIRED_CONFIG_KEYS
 from oct_turrets.exceptions import InvalidConfiguration
@@ -93,3 +94,11 @@ def clean_tar_tmp(dir_name, is_tar):
         shutil.rmtree(dir_name)
     except OSError:
         pass  # files already removed
+
+
+def import_object(path):
+    module_path = '.'.join(path.split('.')[:-1])
+    object_name = path.split('.')[-1]
+    module = importlib.import_module(module_path)
+    obj = getattr(module, object_name)
+    return obj


### PR DESCRIPTION
User can now define in configuration which Turret or Cannon class he/she want to use.
If not specified the default one are used.

Turret config example:
```json
{"name": "myname", "cannons": 2, "rampup": 0, "script": "test_scripts/my_script.py", "turret_class": "foo.BarTurret", "cannon_class": "foo.HamCannon"}
```