### PR TITLE
Added Cannon setup/tear_down

### DIFF
--- a/oct_turrets/base.py
+++ b/oct_turrets/base.py
@@ -5,6 +5,21 @@ import zmq
 import uuid
 from threading import Thread
 
+from oct_turrets import utils
+
+DEFAULT_TURRET_CLASS = 'oct_turrets.turret.Turret'
+DEFAULT_CANNON_CLASS = 'oct_turrets.cannon.Cannon'
+
+
+def get_turret_class(path=None):
+    path = path or DEFAULT_TURRET_CLASS
+    return utils.import_object(path)
+
+
+def get_cannon_class(path=None):
+    path = path or DEFAULT_CANNON_CLASS
+    return utils.import_object(path)
+
 
 class BaseTurret(object):
     """The base turret class

--- a/oct_turrets/base.py
+++ b/oct_turrets/base.py
@@ -142,22 +142,37 @@ class BaseCannon(Thread):
         self.script_module = script_module
         self.run_loop = True
         self.config = config
+        self.transaction_context = {}
 
         self.result_socket = context.socket(zmq.PUSH)
         self.result_socket.connect("tcp://{}:{}".format(self.config['hq_address'], self.config['hq_rc']))
+
+    def setup(self):
+        """This method will be call before the run method, use it to setup all needed datas.
+        The setup time will not be included in the scriptrun_time
+        """
+        pass
 
     def run(self):
         """The main run method for the cannon
         """
         raise NotImplementedError("run method must be implemented")
 
+    def tear_down(self):
+        """This method will be call once the run method has ended. Since the transaction instance will never be
+        destroyed before the end of the test, use this method to clean and reset all variables, etc.
+        The tear down time will not be included in the scriptrun_time
+        """
+        pass
+
 
 class BaseTransaction(object):
     """The base transaction class for writing tests
     """
 
-    def __init__(self, config):
+    def __init__(self, config, context=None):
         self.config = config
+        self.context = context or {}
         self.custom_timers = {}
 
     def setup(self):

--- a/oct_turrets/cannon.py
+++ b/oct_turrets/cannon.py
@@ -9,7 +9,8 @@ class Cannon(BaseCannon):
         """The main run method of the canon
         """
         elapsed = 0
-        trans = self.script_module.Transaction(self.config)
+        trans = self.script_module.Transaction(self.config,
+                                               self.transaction_context)
         trans.custom_timers = {}
 
         while self.run_loop:

--- a/oct_turrets/start_turret.py
+++ b/oct_turrets/start_turret.py
@@ -6,7 +6,7 @@ import logging
 import tarfile
 import tempfile
 import argparse
-from oct_turrets.turret import Turret
+from oct_turrets.base import get_turret_class
 from oct_turrets.exceptions import InvalidConfiguration, InvalidTarTurret
 from oct_turrets.utils import validate_conf, clean_tar_tmp, load_file
 
@@ -76,6 +76,7 @@ def start(args):
     else:
         module, config = from_config(args.config)
 
+    Turret = get_turret_class(config.get('turret_class'))
     turret = Turret(config, module, unique_id)
 
     try:

--- a/oct_turrets/turret.py
+++ b/oct_turrets/turret.py
@@ -4,8 +4,7 @@ import json
 import logging
 import traceback
 
-from oct_turrets.base import BaseTurret
-from oct_turrets.cannon import Cannon
+from oct_turrets.base import BaseTurret, get_cannon_class
 
 log = logging.getLogger(__name__)
 
@@ -79,6 +78,7 @@ class Turret(BaseTurret):
         else:
             timeout = 1000
 
+        Cannon = get_cannon_class(self.config.get('cannon_class'))
         try:
             while self.run_loop:
                 if len(self.cannons) < self.config['cannons'] and time.time() - last_insert >= rampup:

--- a/oct_turrets/utils.py
+++ b/oct_turrets/utils.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import shutil
 import tempfile
+import importlib
 
 from oct_turrets.config import REQUIRED_CONFIG_KEYS
 from oct_turrets.exceptions import InvalidConfiguration
@@ -93,3 +94,11 @@ def clean_tar_tmp(dir_name, is_tar):
         shutil.rmtree(dir_name)
     except OSError:
         pass  # files already removed
+
+
+def import_object(path):
+    module_path = '.'.join(path.split('.')[:-1])
+    object_name = path.split('.')[-1]
+    module = importlib.import_module(module_path)
+    obj = getattr(module, object_name)
+    return obj


### PR DESCRIPTION
This PR comes after #8,

It aims 2 things:

### Make `Cannon` more configurable:
`Cannon` can only receive a static configuration from its `Turret`'s config. Now the `Turret` pass its `self.transaction_context` to `Cannon`s when they are instanciated. So `Turret`, can compute things to pass to `Cannon`.

### Make `Turret's `setup` and `tear_down`: 
I know `Cannon`'s `setup`/`tear_down` are not counted in timings, but these operations can have a real cost in term of timing and loading. Put these methods in `Turret` helps to set up an environment before make the real load. In combination with `Cannon.transaction_context`, we could imagine to prepare a lot of things in `setup` and give these things to its `Transaction`s

Say me if it is good, I'll update OCT core and documentation.