### PR TITLE
Remove TAR & conf_file exlusivity

### DIFF
--- a/oct_turrets/start_turret.py
+++ b/oct_turrets/start_turret.py
@@ -59,7 +59,8 @@ def from_config(config_path):
     """
     config = validate_conf(config_path)
     cfg_path = os.path.dirname(config_path)
-    module_file = os.path.join(cfg_path, config['script'])
+    module_dir = config['script_dir'] if 'script_dir' in config else cfg_path
+    module_file = os.path.join(module_dir, config['script'])
     module = load_file(module_file)
     return module, config
 
@@ -72,9 +73,12 @@ def start(args):
         dir_name = "{}-{}".format(os.path.basename(args.tar).split('.')[0], unique_id)
         dir_name = os.path.join(tempfile.gettempdir(), dir_name)
         module, config = from_tar(args.tar, unique_id, dir_name)
+        if args.config_file is not None:
+            _, config = from_config(args.config_file)
         is_tar = True
     else:
-        module, config = from_config(args.config)
+        module, config = from_config(args.config_file)
+        dir_name = None
 
     Turret = get_turret_class(config.get('turret_class'))
     turret = Turret(config, module, unique_id)
@@ -91,9 +95,8 @@ def start(args):
 def main():
 
     parser = argparse.ArgumentParser(description='Give parameters for start a turret instance')
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument('--config-file', type=str, default=None, help='path for json configuration file')
-    group.add_argument('--tar', type=str, default=None, help='Path for the tarball to use')
+    parser.add_argument('--config-file', type=str, default=None, help='path for json configuration file')
+    parser.add_argument('--tar', type=str, default=None, help='Path for the tarball to use')
     args = parser.parse_args()
 
     if args.config_file is None and args.tar is None:


### PR DESCRIPTION
I wanted to use a packaged turret with different parameters.
Actually a turret is configured by its config.json file. I let user choose a tar file and specify a conf file.