### PR TITLE
Added set transaction context from HQ message

### DIFF
--- a/oct_turrets/base.py
+++ b/oct_turrets/base.py
@@ -51,6 +51,7 @@ class BaseTurret(object):
         self.setup_sockets()
 
         self.init_commands()
+        self.transaction_context = {}
 
     def init_commands(self):
         """Initialize the commands dictionnary. This dict will be used when master send a command to interpret them
@@ -127,6 +128,9 @@ class BaseTurret(object):
         """
         raise NotImplementedError("run method must be implemented")
 
+    def set_transaction_context(self, transaction_context):
+        self.transaction_context.update(transaction_context)
+
 
 class BaseCannon(Thread):
     """The base cannon class, inherit from thread
@@ -136,13 +140,14 @@ class BaseCannon(Thread):
     :param script_module: the module containing the test
     """
 
-    def __init__(self, start_time, script_module, turret_uuid, context, config):
+    def __init__(self, start_time, script_module, turret_uuid, context, config,
+                 transaction_context):
         super(BaseCannon, self).__init__()
         self.start_time = start_time
         self.script_module = script_module
         self.run_loop = True
         self.config = config
-        self.transaction_context = {}
+        self.transaction_context = transaction_context
 
         self.result_socket = context.socket(zmq.PUSH)
         self.result_socket.connect("tcp://{}:{}".format(self.config['hq_address'], self.config['hq_rc']))

--- a/oct_turrets/turret.py
+++ b/oct_turrets/turret.py
@@ -19,6 +19,7 @@ class Turret(BaseTurret):
         self.commands['start'] = self.run
         self.commands['status_request'] = self.send_status
         self.commands['kill'] = self.kill
+        self.commands['set_transaction_context'] = self.set_transaction_context
 
     def send_status(self, msg=None):
         """Reply to the master by sending the current status
@@ -81,7 +82,8 @@ class Turret(BaseTurret):
         # Setup cannons
         Cannon = get_cannon_class(self.config.get('cannon_class'))
         for i in range(self.config['cannons']):
-            cannon = Cannon(self.start_time, self.script_module, self.uuid, self.context, self.config)
+            cannon = Cannon(self.start_time, self.script_module, self.uuid, self.context, self.config,
+                            transaction_context=self.transaction_context)
             cannon.setup()
             cannon.daemon = True
             self.cannons.append(cannon)


### PR DESCRIPTION
I added the possibility to receive a `'set_transaction_context'` from HQ and put these data in `Turret.transaction_context`.

It helps to create something from HQ and give dynamic data to turrets.